### PR TITLE
Fix: appliedDate only updates when provided

### DIFF
--- a/src/main/java/com/jerome/jobtracker/controller/JobApplicationController.java
+++ b/src/main/java/com/jerome/jobtracker/controller/JobApplicationController.java
@@ -44,7 +44,12 @@ public class JobApplicationController {
                     job.setCompany(updatedJob.getCompany());
                     job.setPosition(updatedJob.getPosition());
                     job.setStatus(updatedJob.getStatus());
-                    job.setAppliedDate((updatedJob.getAppliedDate()));
+
+                    // only update appliedDate if it's not null
+                    if (updatedJob.getAppliedDate() != null) {
+                        job.setAppliedDate(updatedJob.getAppliedDate());
+                    };
+
                     job.setNotes(updatedJob.getNotes());
                     return repository.save(job);
                 })


### PR DESCRIPTION
This PR updates the PUT /api/jobs/{id} endpoint to only modify the appliedDate field if it is explicitly provided in the request body. Prevents accidental overwriting with null when the field is omitted. 